### PR TITLE
Readability tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM debian:jessie
 
 RUN apt-get update -qq && \
-    apt-get install -y -qq --no-install-recommends ucspi-tcp-ipv6 fortune-mod fortunes && \
+    apt-get install -y -qq --no-install-recommends \
+            ucspi-tcp-ipv6 \
+            fortune-mod fortunes && \
     rm -rf /var/lib/apt/lists/*
 ADD fortune_wrapper.sh /srv/
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@ Fortune as a Service
 
 This is a toy repository. The service serves the output of the fortune
 command via HTTP.
+
+To run Fortune as a Service:
+
+    docker run -p 8080:8080 andis/http-fortune


### PR DESCRIPTION
This pull request adds two minor readability/usability tweaks.

Have you thought about setting the project's website on GitHub to the [Docker Hub](https://registry.hub.docker.com/u/andis/http-fortune/) page?

Also, since you already have a `v0.2.0` tag, you might want to delete the `0.2.0` tag on GitHub.
