### PR TITLE
Move from Debian Jessie to Alpine 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-FROM debian:jessie
+FROM alpine:3.6
 
-RUN apt-get update -qq && \
-    apt-get install -y -qq --no-install-recommends \
-            ucspi-tcp-ipv6 \
-            fortune-mod fortunes && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk --no-cache add ucspi-tcp6 fortune
 ADD fortune_wrapper.sh /srv/
 EXPOSE 8080
 USER nobody

--- a/fortune_wrapper.sh
+++ b/fortune_wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BODY="$(/usr/games/fortune)"
+BODY="$(/usr/bin/fortune)"
 LENGTH=$((${#BODY} + 1)) # body + newline
 
 cat <<EOS


### PR DESCRIPTION
This pull request changes the base image for docker-http-fortune from Debian Jessie to Alpine Linux.