### PR TITLE
Enable verbose output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN apk --no-cache add ucspi-tcp6 fortune
 ADD fortune_wrapper.sh /srv/
 EXPOSE 8080
 USER nobody
-CMD ["tcpserver", "-H", "0.0.0.0", "8080", "/srv/fortune_wrapper.sh"]
+CMD ["tcpserver", "-vH", "0.0.0.0", "8080", "/srv/fortune_wrapper.sh"]


### PR DESCRIPTION
This pull request enables verbose mode for tcpserver.

While verbose output would of course be too verbose for actual production systems, I quite like the additional output since it allows users to experiment with `docker logs` et al.